### PR TITLE
Retry transient Android payment failures

### DIFF
--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -5,7 +5,10 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.compose'
 }
 
-def kronorMerchantToken = project.hasProperty('KRONOR_MERCHANT_TOKEN') ? project.property('KRONOR_MERCHANT_TOKEN') : System.getenv('KRONOR_MERCHANT_TOKEN') ?: '""'
+def kronorMerchantToken = project.hasProperty('KRONOR_MERCHANT_TOKEN') ? project.property('KRONOR_MERCHANT_TOKEN') : System.getenv('KRONOR_MERCHANT_TOKEN') ?: ''
+def escapedKronorMerchantToken = kronorMerchantToken
+        .replace('\\', '\\\\')
+        .replace('"', '\\"')
 
 android {
     namespace 'io.kronor.example'
@@ -22,7 +25,7 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
-        buildConfigField("String", "KRONOR_MERCHANT_TOKEN", kronorMerchantToken)
+        buildConfigField("String", "KRONOR_MERCHANT_TOKEN", "\"${escapedKronorMerchantToken}\"")
     }
 
     buildTypes {

--- a/kronor_api/build.gradle
+++ b/kronor_api/build.gradle
@@ -98,6 +98,7 @@ dependencies {
 
     implementation "androidx.core:core-ktx:$core_ktx_version"
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
     implementation('com.apollographql.apollo3:apollo-runtime:3.8.6')

--- a/kronor_api/src/main/java/io/kronor/api/Requests.kt
+++ b/kronor_api/src/main/java/io/kronor/api/Requests.kt
@@ -22,8 +22,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.retryWhen
 import okhttp3.OkHttpClient
 import java.lang.Exception
 import java.util.UUID
@@ -35,8 +35,8 @@ enum class Environment {
 }
 
 private const val TemporaryFailure = "TEMPORARY_FAILURE"
-// Five attempts over a 15-second backoff window before the error reaches the UI.
-internal val DefaultRetryDelaysMillis = listOf(1_000L, 2_000L, 4_000L, 8_000L)
+// Six attempts over a 15.5-second backoff window before the error reaches the UI.
+internal val DefaultRetryDelaysMillis = listOf(500L, 1_000L, 2_000L, 4_000L, 8_000L)
 
 class Requests internal constructor(
     val kronorApolloClient: ApolloClient,
@@ -48,14 +48,21 @@ class Requests internal constructor(
         retryDelaysMillis = DefaultRetryDelaysMillis
     )
 
-    fun getPaymentRequests(): Flow<List<PaymentStatusSubscription.PaymentRequest>> {
+    fun getPaymentRequests(
+        onRetry: () -> Unit = {},
+        onRecovered: () -> Unit = {}
+    ): Flow<List<PaymentStatusSubscription.PaymentRequest>> {
         return kronorApolloClient.subscription(
             PaymentStatusSubscription()
         ).toFlow().map { response ->
             response.data?.paymentRequests ?: throw KronorError.GraphQlError(
                 ApiError(response.errors ?: emptyList(), response.extensions)
             )
-        }.filterNotNull().retryTransientErrors(retryDelaysMillis).catch { error ->
+        }.filterNotNull().retryTransientErrors(
+            delaysMillis = retryDelaysMillis,
+            onRetry = onRetry,
+            onRecovered = onRecovered
+        ).catch { error ->
             when (error) {
                 is KronorError -> throw error
                 is ApolloException -> throw KronorError.NetworkError(error)
@@ -123,6 +130,7 @@ internal fun Throwable.isRetryableKronorError(): Boolean = when (this) {
 
 internal suspend fun <T> retryTransientErrors(
     delaysMillis: List<Long> = DefaultRetryDelaysMillis,
+    onRetry: () -> Unit = {},
     block: suspend () -> Result<T>
 ): Result<T> {
     var result = block()
@@ -130,20 +138,37 @@ internal suspend fun <T> retryTransientErrors(
         if (result.exceptionOrNull()?.isRetryableKronorError() != true) {
             return result
         }
+        onRetry()
         delay(delayMillis)
         result = block()
     }
     return result
 }
 
-internal fun <T> Flow<T>.retryTransientErrors(delaysMillis: List<Long>): Flow<T> =
-    retryWhen { cause, attempt ->
-        val retry = cause.isRetryableKronorError() && attempt < delaysMillis.size
-        if (retry) {
-            delay(delaysMillis[attempt.toInt()])
+internal fun <T> Flow<T>.retryTransientErrors(
+    delaysMillis: List<Long>,
+    onRetry: () -> Unit = {},
+    onRecovered: () -> Unit = {}
+): Flow<T> = flow {
+    var consecutiveFailures = 0
+    while (true) {
+        try {
+            this@retryTransientErrors.collect { value ->
+                consecutiveFailures = 0
+                onRecovered()
+                emit(value)
+            }
+            return@flow
+        } catch (cause: Throwable) {
+            if (!cause.isRetryableKronorError() || consecutiveFailures >= delaysMillis.size) {
+                throw cause
+            }
+            onRetry()
+            delay(delaysMillis[consecutiveFailures])
+            consecutiveFailures += 1
         }
-        retry
     }
+}
 
 suspend fun <D : Operation.Data> ApolloCall<D>.executeMapKronorError(): Result<D> {
     return try {
@@ -203,14 +228,15 @@ data class PaymentRequestResult(
 
 
 suspend fun Requests.makeNewPaymentRequest(
-    paymentRequestArgs: PaymentRequestArgs
+    paymentRequestArgs: PaymentRequestArgs,
+    onRetry: () -> Unit = {}
 ): Result<PaymentRequestResult> {
     val androidVersion = java.lang.Double.parseDouble(
         java.lang.String(Build.VERSION.RELEASE).replaceAll("(\\d+[.]\\d+)(.*)", "$1")
     )
     val os = "android"
     val userAgent = "kronor_android_sdk/${BuildConfig.VERSION}"
-    return retryTransientErrors {
+    return retryTransientErrors(onRetry = onRetry) {
         makeNewPaymentRequestOnce(paymentRequestArgs, androidVersion, os, userAgent)
     }
 }

--- a/kronor_api/src/main/java/io/kronor/api/Requests.kt
+++ b/kronor_api/src/main/java/io/kronor/api/Requests.kt
@@ -18,12 +18,15 @@ import io.kronor.api.type.PayPalPaymentInput
 import io.kronor.api.type.PaymentCancelInput
 import io.kronor.api.type.SwishPaymentInput
 import io.kronor.api.type.VippsPaymentInput
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.retryWhen
 import okhttp3.OkHttpClient
 import java.lang.Exception
-import java.util.*
+import java.util.UUID
 import kotlin.Result.Companion.failure
 import kotlin.Result.Companion.success
 
@@ -31,30 +34,34 @@ enum class Environment {
     Staging, Production
 }
 
-class Requests(token: String, env: Environment) {
+private const val TemporaryFailure = "TEMPORARY_FAILURE"
+// Five attempts over a 15-second backoff window before the error reaches the UI.
+internal val DefaultRetryDelaysMillis = listOf(1_000L, 2_000L, 4_000L, 8_000L)
 
-    private val okHttpClient =
-        OkHttpClient.Builder().build()
+class Requests internal constructor(
+    val kronorApolloClient: ApolloClient,
+    private val retryDelaysMillis: List<Long>
+) {
 
-    val kronorApolloClient = ApolloClient.Builder().httpServerUrl(
-        when (env) {
-            Environment.Staging -> "https://staging.kronor.io/v1/graphql"
-            Environment.Production -> "https://kronor.io/v1/graphql"
-        }
-    ).webSocketServerUrl(
-        when (env) {
-            Environment.Staging -> "wss://staging.kronor.io/v1/graphql"
-            Environment.Production -> "wss://kronor.io/v1/graphql"
-        }
+    constructor(token: String, env: Environment) : this(
+        kronorApolloClient = buildApolloClient(token, env),
+        retryDelaysMillis = DefaultRetryDelaysMillis
     )
-        .addHttpHeader("Authorization", "Bearer $token")
-        .wsProtocol(SubscriptionWsProtocol.Factory(connectionPayload = { mapOf("headers" to (mapOf("Authorization" to "Bearer $token"))) }))
-        .okHttpClient(okHttpClient).build()
 
     fun getPaymentRequests(): Flow<List<PaymentStatusSubscription.PaymentRequest>> {
         return kronorApolloClient.subscription(
             PaymentStatusSubscription()
-        ).toFlow().map { response -> response.data?.paymentRequests }.filterNotNull()
+        ).toFlow().map { response ->
+            response.data?.paymentRequests ?: throw KronorError.GraphQlError(
+                ApiError(response.errors ?: emptyList(), response.extensions)
+            )
+        }.filterNotNull().retryTransientErrors(retryDelaysMillis).catch { error ->
+            when (error) {
+                is KronorError -> throw error
+                is ApolloException -> throw KronorError.NetworkError(error)
+                else -> throw error
+            }
+        }
     }
 
     suspend fun cancelPayment(): Result<String?> {
@@ -63,6 +70,33 @@ class Requests(token: String, env: Environment) {
                 pay = PaymentCancelInput(idempotencyKey = UUID.randomUUID().toString())
             )
         ).executeMapKronorError().map { it.cancelPayment.waitToken }
+    }
+
+    companion object {
+        private fun buildApolloClient(token: String, env: Environment): ApolloClient {
+            val httpServerUrl = when (env) {
+                Environment.Staging -> "https://staging.kronor.io/v1/graphql"
+                Environment.Production -> "https://kronor.io/v1/graphql"
+            }
+            val webSocketServerUrl = when (env) {
+                Environment.Staging -> "wss://staging.kronor.io/v1/graphql"
+                Environment.Production -> "wss://kronor.io/v1/graphql"
+            }
+
+            return ApolloClient.Builder()
+                .httpServerUrl(httpServerUrl)
+                .webSocketServerUrl(webSocketServerUrl)
+                .addHttpHeader("Authorization", "Bearer $token")
+                .wsProtocol(
+                    SubscriptionWsProtocol.Factory(
+                        connectionPayload = {
+                            mapOf("headers" to mapOf("Authorization" to "Bearer $token"))
+                        }
+                    )
+                )
+                .okHttpClient(OkHttpClient.Builder().build())
+                .build()
+        }
     }
 
 }
@@ -79,15 +113,54 @@ sealed class KronorError : Throwable() {
     data class FlowError(val e: String) : KronorError()
 }
 
+internal fun Throwable.isRetryableKronorError(): Boolean = when (this) {
+    is KronorError.NetworkError, is ApolloException -> true
+    is KronorError.GraphQlError -> e.errors.any { error ->
+        error.extensions?.get("type") == TemporaryFailure
+    }
+    else -> false
+}
+
+internal suspend fun <T> retryTransientErrors(
+    delaysMillis: List<Long> = DefaultRetryDelaysMillis,
+    block: suspend () -> Result<T>
+): Result<T> {
+    var result = block()
+    for (delayMillis in delaysMillis) {
+        if (result.exceptionOrNull()?.isRetryableKronorError() != true) {
+            return result
+        }
+        delay(delayMillis)
+        result = block()
+    }
+    return result
+}
+
+internal fun <T> Flow<T>.retryTransientErrors(delaysMillis: List<Long>): Flow<T> =
+    retryWhen { cause, attempt ->
+        val retry = cause.isRetryableKronorError() && attempt < delaysMillis.size
+        if (retry) {
+            delay(delaysMillis[attempt.toInt()])
+        }
+        retry
+    }
+
 suspend fun <D : Operation.Data> ApolloCall<D>.executeMapKronorError(): Result<D> {
     return try {
         val response = this.execute()
-        response.data?.let {
+        val errors = response.errors.orEmpty()
+        if (errors.isNotEmpty()) {
+            failure(
+                KronorError.GraphQlError(
+                    ApiError(errors, response.extensions)
+                )
+            )
+        } else response.data?.let {
             success(it)
         } ?: failure(
             KronorError.GraphQlError(
                 ApiError(
-                    response.errors ?: emptyList(), response.extensions
+                    emptyList(), response.extensions
                 )
             )
         )
@@ -102,8 +175,26 @@ data class PaymentRequestArgs(
     val deviceFingerprint: String,
     val appName: String,
     val appVersion: String,
-    val paymentMethod: PaymentMethod
-)
+    val paymentMethod: PaymentMethod,
+    val idempotencyKey: String
+) {
+    constructor(
+        returnUrl: String,
+        merchantReturnUrl: String,
+        deviceFingerprint: String,
+        appName: String,
+        appVersion: String,
+        paymentMethod: PaymentMethod
+    ) : this(
+        returnUrl = returnUrl,
+        merchantReturnUrl = merchantReturnUrl,
+        deviceFingerprint = deviceFingerprint,
+        appName = appName,
+        appVersion = appVersion,
+        paymentMethod = paymentMethod,
+        idempotencyKey = UUID.randomUUID().toString()
+    )
+}
 
 data class PaymentRequestResult(
     val paymentId: String,
@@ -119,12 +210,22 @@ suspend fun Requests.makeNewPaymentRequest(
     )
     val os = "android"
     val userAgent = "kronor_android_sdk/${BuildConfig.VERSION}"
-    return when (paymentRequestArgs.paymentMethod) {
+    return retryTransientErrors {
+        makeNewPaymentRequestOnce(paymentRequestArgs, androidVersion, os, userAgent)
+    }
+}
+
+private suspend fun Requests.makeNewPaymentRequestOnce(
+    paymentRequestArgs: PaymentRequestArgs,
+    androidVersion: Double,
+    os: String,
+    userAgent: String
+): Result<PaymentRequestResult> = when (paymentRequestArgs.paymentMethod) {
         is PaymentMethod.CreditCard -> {
             kronorApolloClient.mutation(
                 CreditCardPaymentMutation(
                     payment = CreditCardPaymentInput(
-                        idempotencyKey = UUID.randomUUID().toString(),
+                        idempotencyKey = paymentRequestArgs.idempotencyKey,
                         returnUrl = paymentRequestArgs.merchantReturnUrl,
                         merchantReturnUrl = Optional.present(paymentRequestArgs.merchantReturnUrl)
                     ), deviceInfo = AddSessionDeviceInformationInput(
@@ -143,7 +244,7 @@ suspend fun Requests.makeNewPaymentRequest(
             kronorApolloClient.mutation(
                 MobilePayPaymentMutation(
                     payment = MobilePayPaymentInput(
-                        idempotencyKey = UUID.randomUUID().toString(),
+                        idempotencyKey = paymentRequestArgs.idempotencyKey,
                         returnUrl = paymentRequestArgs.merchantReturnUrl,
                         merchantReturnUrl = Optional.present(paymentRequestArgs.merchantReturnUrl),
                         userFlow = Optional.present(MobilePayUserFlow.NativeRedirect)
@@ -163,7 +264,7 @@ suspend fun Requests.makeNewPaymentRequest(
             kronorApolloClient.mutation(
                 VippsPaymentMutation(
                     payment = VippsPaymentInput(
-                        idempotencyKey = UUID.randomUUID().toString(),
+                        idempotencyKey = paymentRequestArgs.idempotencyKey,
                         returnUrl = paymentRequestArgs.merchantReturnUrl,
                         merchantReturnUrl = Optional.present(paymentRequestArgs.merchantReturnUrl)
                     ), deviceInfo = AddSessionDeviceInformationInput(
@@ -183,7 +284,7 @@ suspend fun Requests.makeNewPaymentRequest(
                 payment = SwishPaymentInput(
                     customerSwishNumber = Optional.presentIfNotNull(paymentRequestArgs.paymentMethod.customerSwishNumber),
                     flow = if (paymentRequestArgs.paymentMethod.customerSwishNumber == null) "mcom" else "ecom",
-                    idempotencyKey = UUID.randomUUID().toString(),
+                    idempotencyKey = paymentRequestArgs.idempotencyKey,
                     returnUrl = paymentRequestArgs.merchantReturnUrl,
                     merchantReturnUrl = Optional.present(paymentRequestArgs.merchantReturnUrl)
                 ), deviceInfo = AddSessionDeviceInformationInput(
@@ -201,7 +302,7 @@ suspend fun Requests.makeNewPaymentRequest(
             kronorApolloClient.mutation(
                 PayPalPaymentMutation(
                     payment = PayPalPaymentInput(
-                        idempotencyKey = UUID.randomUUID().toString(),
+                        idempotencyKey = paymentRequestArgs.idempotencyKey,
                         returnUrl = paymentRequestArgs.returnUrl,
                         merchantReturnUrl = Optional.present(paymentRequestArgs.merchantReturnUrl)
                     ), deviceInfo = AddSessionDeviceInformationInput(
@@ -220,7 +321,7 @@ suspend fun Requests.makeNewPaymentRequest(
             kronorApolloClient.mutation(
                 BankTransferPaymentMutation(
                     payment = BankTransferPaymentInput(
-                        idempotencyKey = UUID.randomUUID().toString(),
+                        idempotencyKey = paymentRequestArgs.idempotencyKey,
                         returnUrl = paymentRequestArgs.returnUrl,
                         merchantReturnUrl = Optional.present(paymentRequestArgs.merchantReturnUrl),
                         flow = Optional.present("mcom")
@@ -240,4 +341,3 @@ suspend fun Requests.makeNewPaymentRequest(
             failure(Exception("Impossible!"))
         }
     }
-}

--- a/kronor_api/src/test/java/io/kronor/api/RequestsRetryTest.kt
+++ b/kronor_api/src/test/java/io/kronor/api/RequestsRetryTest.kt
@@ -7,6 +7,8 @@ import io.kronor.api.type.AddSessionDeviceInformationInput
 import io.kronor.api.type.CreditCardPaymentInput
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -43,13 +45,18 @@ class RequestsRetryTest {
         server.enqueue(successResponse())
 
         val idempotencyKey = "logical-payment-attempt"
-        val result = retryTransientErrors(listOf(0L, 0L, 0L)) {
+        var retryNotifications = 0
+        val result = retryTransientErrors(
+            delaysMillis = listOf(0L, 0L, 0L),
+            onRetry = { retryNotifications += 1 }
+        ) {
             client.mutation(creditCardMutation(idempotencyKey)).executeMapKronorError()
         }
 
         assertTrue(result.isSuccess)
         assertEquals("wait-token", result.getOrThrow().newCreditCardPayment.waitToken)
         assertEquals(3, server.requestCount)
+        assertEquals(2, retryNotifications)
         repeat(3) {
             val requestBody = server.takeRequest().body.readUtf8()
             assertTrue(requestBody.contains("\"idempotencyKey\":\"$idempotencyKey\""))
@@ -73,16 +80,44 @@ class RequestsRetryTest {
     @Test
     fun subscriptionTransportFailureResubscribesUntilItRecovers() = runBlocking {
         var subscriptions = 0
+        var retryNotifications = 0
+        var recoveryNotifications = 0
         val status = flow {
             subscriptions += 1
             if (subscriptions < 3) {
                 throw ApolloNetworkException("socket closed")
             }
             emit("paid")
-        }.retryTransientErrors(listOf(0L, 0L, 0L)).first()
+        }.retryTransientErrors(
+            delaysMillis = listOf(0L, 0L, 0L),
+            onRetry = { retryNotifications += 1 },
+            onRecovered = { recoveryNotifications += 1 }
+        ).first()
 
         assertEquals("paid", status)
         assertEquals(3, subscriptions)
+        assertEquals(2, retryNotifications)
+        assertEquals(1, recoveryNotifications)
+    }
+
+    @Test
+    fun successfulSubscriptionUpdateResetsTheConsecutiveFailureBudget() = runBlocking {
+        var subscriptions = 0
+        val statuses = flow {
+            subscriptions += 1
+            when (subscriptions) {
+                1 -> throw ApolloNetworkException("socket closed")
+                2 -> {
+                    emit("processing")
+                    throw ApolloNetworkException("socket closed again")
+                }
+                3 -> throw ApolloNetworkException("socket closed once more")
+                else -> emit("paid")
+            }
+        }.retryTransientErrors(listOf(0L, 0L)).take(2).toList()
+
+        assertEquals(listOf("processing", "paid"), statuses)
+        assertEquals(4, subscriptions)
     }
 
     @Test

--- a/kronor_api/src/test/java/io/kronor/api/RequestsRetryTest.kt
+++ b/kronor_api/src/test/java/io/kronor/api/RequestsRetryTest.kt
@@ -1,0 +1,141 @@
+package io.kronor.api
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.Optional
+import com.apollographql.apollo3.exception.ApolloNetworkException
+import io.kronor.api.type.AddSessionDeviceInformationInput
+import io.kronor.api.type.CreditCardPaymentInput
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RequestsRetryTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: ApolloClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = ApolloClient.Builder()
+            .httpServerUrl(server.url("/graphql").toString())
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        client.close()
+        server.shutdown()
+    }
+
+    @Test
+    fun temporaryFailureRetriesWithTheSameIdempotencyKey() = runBlocking {
+        server.enqueue(graphQlErrorResponse("TEMPORARY_FAILURE"))
+        server.enqueue(graphQlErrorResponse("TEMPORARY_FAILURE"))
+        server.enqueue(successResponse())
+
+        val idempotencyKey = "logical-payment-attempt"
+        val result = retryTransientErrors(listOf(0L, 0L, 0L)) {
+            client.mutation(creditCardMutation(idempotencyKey)).executeMapKronorError()
+        }
+
+        assertTrue(result.isSuccess)
+        assertEquals("wait-token", result.getOrThrow().newCreditCardPayment.waitToken)
+        assertEquals(3, server.requestCount)
+        repeat(3) {
+            val requestBody = server.takeRequest().body.readUtf8()
+            assertTrue(requestBody.contains("\"idempotencyKey\":\"$idempotencyKey\""))
+        }
+    }
+
+    @Test
+    fun fatalGraphQlFailureIsNotRetried() = runBlocking {
+        server.enqueue(graphQlErrorResponse("VALIDATION_FAILURE"))
+        server.enqueue(successResponse())
+
+        val result = retryTransientErrors(listOf(0L, 0L)) {
+            client.mutation(creditCardMutation("fatal-attempt")).executeMapKronorError()
+        }
+
+        assertTrue(result.isFailure)
+        assertEquals(1, server.requestCount)
+        assertFalse(result.exceptionOrNull()?.isRetryableKronorError() == true)
+    }
+
+    @Test
+    fun subscriptionTransportFailureResubscribesUntilItRecovers() = runBlocking {
+        var subscriptions = 0
+        val status = flow {
+            subscriptions += 1
+            if (subscriptions < 3) {
+                throw ApolloNetworkException("socket closed")
+            }
+            emit("paid")
+        }.retryTransientErrors(listOf(0L, 0L, 0L)).first()
+
+        assertEquals("paid", status)
+        assertEquals(3, subscriptions)
+    }
+
+    @Test
+    fun subscriptionFailureStopsAfterTheRetryBudget() = runBlocking {
+        var subscriptions = 0
+        val result = runCatching {
+            flow<String> {
+                subscriptions += 1
+                throw ApolloNetworkException("socket closed")
+            }.retryTransientErrors(listOf(0L, 0L)).first()
+        }
+
+        assertTrue(result.exceptionOrNull() is ApolloNetworkException)
+        assertEquals(3, subscriptions)
+    }
+
+    @Test
+    fun retryBudgetIsBounded() = runBlocking {
+        var attempts = 0
+        val result: Result<Unit> = retryTransientErrors(listOf(0L, 0L, 0L, 0L)) {
+            attempts += 1
+            Result.failure(ApolloNetworkException("offline"))
+        }
+
+        assertTrue(result.isFailure)
+        assertEquals(5, attempts)
+    }
+
+    private fun creditCardMutation(idempotencyKey: String) = CreditCardPaymentMutation(
+        payment = CreditCardPaymentInput(
+            idempotencyKey = idempotencyKey,
+            returnUrl = "https://merchant.example/return",
+            merchantReturnUrl = Optional.present("https://merchant.example/return")
+        ),
+        deviceInfo = AddSessionDeviceInformationInput(
+            browserName = "test-app",
+            browserVersion = "1.0",
+            fingerprint = "fingerprint",
+            osName = "android",
+            osVersion = "15",
+            userAgent = "kronor_android_sdk/test"
+        )
+    )
+
+    private fun graphQlErrorResponse(type: String) = MockResponse()
+        .setHeader("Content-Type", "application/json")
+        .setBody(
+            """{"errors":[{"message":"failed","extensions":{"type":"$type"}}]}"""
+        )
+
+    private fun successResponse() = MockResponse()
+        .setHeader("Content-Type", "application/json")
+        .setBody(
+            """{"data":{"newCreditCardPayment":{"waitToken":"wait-token","gateway":"REEPAY"},"addSessionDeviceInformation":{"result":true}}}"""
+        )
+}

--- a/kronor_bank_transfer/build.gradle
+++ b/kronor_bank_transfer/build.gradle
@@ -104,6 +104,7 @@ android {
 
 dependencies {
 
+    implementation "androidx.compose.animation:animation:$compose_ui_version"
     implementation "androidx.navigation:navigation-compose:$compose_nav_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.activity:activity-compose:$compose_activity_version"

--- a/kronor_bank_transfer/src/main/java/io/kronor/component/bank_transfer/BankTransferComponent.kt
+++ b/kronor_bank_transfer/src/main/java/io/kronor/component/bank_transfer/BankTransferComponent.kt
@@ -4,11 +4,20 @@ import android.annotation.SuppressLint
 import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.activity.compose.LocalActivity
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
@@ -62,7 +71,8 @@ fun BankTransferComponent(
 
     BankTransferScreen(
         transition = viewModel::transition,
-        state = viewModel.bankTransferState
+        state = viewModel.bankTransferState,
+        isDelayed = viewModel.isDelayed
     )
 }
 
@@ -71,13 +81,16 @@ fun BankTransferComponent(
 private fun BankTransferScreen(
     transition: (BankTransferStatechart.Companion.Event) -> Unit,
     state: State<BankTransferStatechart.Companion.State>,
+    isDelayed: Boolean,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
     Surface(
         modifier = modifier, color = MaterialTheme.colors.background
     ) {
-        when (state.value) {
+        Column {
+            Box(modifier = Modifier.weight(1f)) {
+                when (state.value) {
             BankTransferStatechart.Companion.State.Initializing -> {
                 LaunchedEffect(Unit) {
                     transition(BankTransferStatechart.Companion.Event.Initialize(context))
@@ -135,6 +148,32 @@ private fun BankTransferScreen(
                     BankTransferPaymentCompleted(modifier = Modifier.fillMaxSize())
                 }
             }
+                }
+            }
+            PaymentDelayedNotice(isDelayed)
+        }
+    }
+}
+
+@Composable
+private fun PaymentDelayedNotice(isDelayed: Boolean) {
+    AnimatedVisibility(visible = isDelayed, enter = fadeIn(), exit = fadeOut()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.payment_taking_longer),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onBackground.copy(alpha = 0.6f),
+                textAlign = TextAlign.Center
+            )
         }
     }
 }

--- a/kronor_bank_transfer/src/main/java/io/kronor/component/bank_transfer/BankTransferViewModel.kt
+++ b/kronor_bank_transfer/src/main/java/io/kronor/component/bank_transfer/BankTransferViewModel.kt
@@ -19,7 +19,6 @@ import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.apollographql.apollo3.exception.ApolloException
 import com.tinder.StateMachine
 import io.kronor.api.ApiError
 import io.kronor.api.KronorError
@@ -57,6 +56,7 @@ class BankTransferViewModel(
     internal val subscribe : Boolean by _subscribe
     private var intentReceived: Boolean = false
     private var deviceFingerprint: String? = null
+    private val paymentIdempotencyKey: String = UUID.randomUUID().toString()
     private val constructedRedirectUrl: Uri =
         BankTransferConfiguration.redirectUrl.buildUpon().appendQueryParameter("paymentMethod", "BankTransfer")
             .appendQueryParameter("sessionToken", BankTransferConfiguration.sessionToken).build()
@@ -129,7 +129,8 @@ class BankTransferViewModel(
                         deviceFingerprint = deviceFingerprint ?: "fingerprint not found",
                         appName = BankTransferConfiguration.appName,
                         appVersion = BankTransferConfiguration.appVersion,
-                        paymentMethod = PaymentMethod.BankTransfer
+                        paymentMethod = PaymentMethod.BankTransfer,
+                        idempotencyKey = paymentIdempotencyKey
                     )
                 )
                 when {
@@ -269,11 +270,9 @@ class BankTransferViewModel(
                     }
                 }
             }
-        } catch (e: ApolloException) {
+        } catch (e: KronorError) {
             Log.d("BankTransferViewModel", "Payment Subscription error: $e")
-            _transition(
-                BankTransferStatechart.Companion.Event.Error(KronorError.NetworkError(e))
-            )
+            _transition(BankTransferStatechart.Companion.Event.Error(e))
         }
     }
 

--- a/kronor_bank_transfer/src/main/java/io/kronor/component/bank_transfer/BankTransferViewModel.kt
+++ b/kronor_bank_transfer/src/main/java/io/kronor/component/bank_transfer/BankTransferViewModel.kt
@@ -70,6 +70,8 @@ class BankTransferViewModel(
     internal val bankTransferState: State<BankTransferStatechart.Companion.State> = _BankTransferState
     var paymentRequest: PaymentStatusSubscription.PaymentRequest? by mutableStateOf(null)
     private var waitToken: String? by mutableStateOf(null)
+    internal var isDelayed: Boolean by mutableStateOf(false)
+        private set
 
     private val _events = MutableSharedFlow<PaymentEvent>()
     val events: Flow<PaymentEvent> = _events
@@ -131,8 +133,10 @@ class BankTransferViewModel(
                         appVersion = BankTransferConfiguration.appVersion,
                         paymentMethod = PaymentMethod.BankTransfer,
                         idempotencyKey = paymentIdempotencyKey
-                    )
+                    ),
+                    onRetry = { isDelayed = true }
                 )
+                isDelayed = false
                 when {
                     waitToken.isFailure -> {
                         Log.d(
@@ -177,6 +181,7 @@ class BankTransferViewModel(
             is BankTransferStatechart.Companion.SideEffect.ResetState -> {
                 this._subscribe.value = false;
                 this.waitToken = null;
+                this.isDelayed = false
             }
 
             is BankTransferStatechart.Companion.SideEffect.NotifyPaymentSuccess -> {
@@ -199,7 +204,10 @@ class BankTransferViewModel(
         // associated with that waitToken and in a status that is not initializing
 
         try {
-            requests.getPaymentRequests().collect { paymentRequestList ->
+            requests.getPaymentRequests(
+                onRetry = { isDelayed = true },
+                onRecovered = { isDelayed = false }
+            ).collect { paymentRequestList ->
                 // If we have a waitToken set in our view model, get the payment request
                 // associated with that waitToken and in a status that is not initializing
                 Log.d("BankTransferViewModel", "Inside Collect")
@@ -271,6 +279,7 @@ class BankTransferViewModel(
                 }
             }
         } catch (e: KronorError) {
+            isDelayed = false
             Log.d("BankTransferViewModel", "Payment Subscription error: $e")
             _transition(BankTransferStatechart.Companion.Event.Error(e))
         }

--- a/kronor_bank_transfer/src/main/res/values-de/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-de/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Bitte warten, bis Ihre Zahlung abgeschlossen ist
   </string>
+    <string name="payment_taking_longer">Die Zahlung dauert länger als üblich. Bitte warten — wir verarbeiten sie noch</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-dk/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-dk/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Gennemfører betaling, vent venligst
   </string>
+    <string name="payment_taking_longer">Betalingen tager længere tid end normalt. Vent venligst — vi behandler den stadig</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-et/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-et/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Palun oodake, makset sooritatakse
   </string>
+    <string name="payment_taking_longer">Makse võtab tavapärasest kauem aega. Palun oodake — töötleme seda endiselt</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-fi/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-fi/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Vahvistetaaan maksutapahtumaasi, odota
   </string>
+    <string name="payment_taking_longer">Maksu kestää tavallista kauemmin. Odota hetki — käsittelemme sitä edelleen</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-fr/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-fr/strings.xml
@@ -15,4 +15,5 @@
   <string name="waiting_for_payment">
     Finalisation de votre paiement, veuillez patienter
   </string>
+    <string name="payment_taking_longer">Le paiement prend plus de temps que prévu. Merci de patienter — il est toujours en cours</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-is/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-is/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Klárar greiðslu, vinsamlegast bíðið
   </string>
+    <string name="payment_taking_longer">Greiðslan tekur lengri tíma en venjulega. Augnablik — við erum enn að vinna úr henni</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-lt/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-lt/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Mokėjimas užbaigiamas, prašome palaukti
   </string>
+    <string name="payment_taking_longer">Mokėjimas užtrunka ilgiau nei įprastai. Palaukite — mes vis dar jį apdorojame</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-lv/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-lv/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Notiek maksājuma apstrāde, lūdzu, uzgaidiet
   </string>
+    <string name="payment_taking_longer">Maksājums aizņem ilgāku laiku nekā parasti. Lūdzu, uzgaidiet — mēs to joprojām apstrādājam</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-nl/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-nl/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     De betaling wordt afgerond, een ogenblik geduld alsjeblieft.
   </string>
+    <string name="payment_taking_longer">De betaling duurt langer dan normaal. Even geduld — we verwerken deze nog</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-no/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-no/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Gjennomfører betaling, vennligst vent
   </string>
+    <string name="payment_taking_longer">Betalingen tar lengre tid enn vanlig. Vent litt — vi behandler den fortsatt</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-pl/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-pl/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Dokonujemy płatności, proszę czekać
   </string>
+    <string name="payment_taking_longer">Płatność trwa dłużej niż zwykle. Prosimy czekać — wciąż ją przetwarzamy</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values-sv/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values-sv/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Slutför din betalning, vänligen vänta.
   </string>
+    <string name="payment_taking_longer">Betalningen tar längre tid än vanligt. Vänta lite — vi behandlar den fortfarande</string>
 </resources>

--- a/kronor_bank_transfer/src/main/res/values/strings.xml
+++ b/kronor_bank_transfer/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="waiting_for_payment">
     Checking the payment status
   </string>
+    <string name="payment_taking_longer">The payment is taking longer than usual. Hang tight — we\'re still processing it</string>
 </resources>

--- a/kronor_swish/build.gradle
+++ b/kronor_swish/build.gradle
@@ -104,6 +104,7 @@ android {
 
 dependencies {
 
+    implementation "androidx.compose.animation:animation:$compose_ui_version"
     implementation "androidx.navigation:navigation-compose:$compose_nav_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.compose.ui:ui:$compose_ui_version"

--- a/kronor_swish/src/main/java/io/kronor/component/swish/SwishComponent.kt
+++ b/kronor_swish/src/main/java/io/kronor/component/swish/SwishComponent.kt
@@ -8,6 +8,9 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.util.Log
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +20,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -99,7 +103,8 @@ fun SwishComponent(
         selectedMethod = viewModel.selectedMethod,
         updateSelectedMethod = viewModel::updateSelectedMethod,
         paymentRequest = viewModel.paymentRequest,
-        merchantLogo = viewModel.merchantLogo()
+        merchantLogo = viewModel.merchantLogo(),
+        isDelayed = viewModel.isDelayed
     )
 }
 
@@ -111,12 +116,13 @@ private fun SwishScreen(
     selectedMethod: State<SelectedMethod?>,
     updateSelectedMethod: (SelectedMethod) -> Unit,
     paymentRequest: PaymentStatusSubscription.PaymentRequest?,
-    @DrawableRes merchantLogo: Int? = null
+    @DrawableRes merchantLogo: Int? = null,
+    isDelayed: Boolean = false
 ) {
 
     val context = LocalContext.current
 
-    SwishWrapper(merchantLogo) {
+    SwishWrapper(merchantLogo, isDelayed) {
         when (state.value) {
             SwishStatechart.Companion.State.PromptingMethod -> {
                 SwishPromptScreen(
@@ -205,7 +211,11 @@ private fun SwishScreen(
 }
 
 @Composable
-private fun SwishWrapper(@DrawableRes merchantLogo: Int? = null, content: @Composable () -> Unit) {
+private fun SwishWrapper(
+    @DrawableRes merchantLogo: Int? = null,
+    isDelayed: Boolean = false,
+    content: @Composable () -> Unit
+) {
     // A surface container using the 'background' color from the theme
     Surface(
         modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background,
@@ -232,6 +242,33 @@ private fun SwishWrapper(@DrawableRes merchantLogo: Int? = null, content: @Compo
             }
             Spacer(modifier = Modifier.height(100.dp))
             content.invoke()
+            PaymentDelayedNotice(isDelayed)
+        }
+    }
+}
+
+@Composable
+private fun PaymentDelayedNotice(isDelayed: Boolean) {
+    AnimatedVisibility(visible = isDelayed, enter = fadeIn(), exit = fadeOut()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.width(16.dp).height(16.dp),
+                strokeWidth = 2.dp
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.payment_taking_longer),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onBackground.copy(alpha = 0.6f),
+                textAlign = TextAlign.Center
+            )
         }
     }
 }
@@ -591,4 +628,3 @@ private fun PreviewSwishPaymentErrored() {
             onPaymentRetry = { }) {}
     }
 }
-

--- a/kronor_swish/src/main/java/io/kronor/component/swish/SwishComponent.kt
+++ b/kronor_swish/src/main/java/io/kronor/component/swish/SwishComponent.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -241,7 +242,14 @@ private fun SwishWrapper(
                 }
             }
             Spacer(modifier = Modifier.height(100.dp))
-            content.invoke()
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                content.invoke()
+            }
             PaymentDelayedNotice(isDelayed)
         }
     }

--- a/kronor_swish/src/main/java/io/kronor/component/swish/SwishViewModel.kt
+++ b/kronor_swish/src/main/java/io/kronor/component/swish/SwishViewModel.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.apollographql.apollo3.exception.ApolloException
 import com.tinder.StateMachine
 import io.kronor.api.ApiError
 import io.kronor.api.KronorError
@@ -54,6 +53,7 @@ class SwishViewModel(
     internal val subscribe : Boolean by _subscribe
     private var intentReceived: Boolean = false
     private var deviceFingerprint: String? = null
+    private val paymentIdempotencyKey: String = UUID.randomUUID().toString()
     private val constructedRedirectUrl: Uri =
         swishConfiguration.redirectUrl.buildUpon().appendQueryParameter("paymentMethod", "swish")
             .appendQueryParameter("sessionToken", swishConfiguration.sessionToken).build()
@@ -134,7 +134,8 @@ class SwishViewModel(
                         deviceFingerprint = deviceFingerprint ?: "fingerprint not found",
                         appName = swishConfiguration.appName,
                         appVersion = swishConfiguration.appVersion,
-                        paymentMethod = PaymentMethod.Swish()
+                        paymentMethod = PaymentMethod.Swish(),
+                        idempotencyKey = paymentIdempotencyKey
                     )
                 )
                 when {
@@ -166,7 +167,8 @@ class SwishViewModel(
                         merchantReturnUrl = constructedRedirectUrl.toString(),
                         deviceFingerprint = deviceFingerprint ?: "fingerprint not found",
                         appName = swishConfiguration.appName,
-                        appVersion = swishConfiguration.appVersion
+                        appVersion = swishConfiguration.appVersion,
+                        idempotencyKey = paymentIdempotencyKey
                     ),
                 )
                 when {
@@ -299,11 +301,9 @@ class SwishViewModel(
                     }
                 }
             }
-        } catch (e: ApolloException) {
+        } catch (e: KronorError) {
             Log.d("SwishViewModel", "Payment Subscription error: $e")
-            _transition(
-                SwishStatechart.Companion.Event.Error(KronorError.NetworkError(e))
-            )
+            _transition(SwishStatechart.Companion.Event.Error(e))
         }
     }
 

--- a/kronor_swish/src/main/java/io/kronor/component/swish/SwishViewModel.kt
+++ b/kronor_swish/src/main/java/io/kronor/component/swish/SwishViewModel.kt
@@ -69,6 +69,8 @@ class SwishViewModel(
     private var waitToken: String? by mutableStateOf(null)
     private var _selectedMethod: MutableState<SelectedMethod?> = mutableStateOf(null)
     internal val selectedMethod: State<SelectedMethod?> = _selectedMethod
+    internal var isDelayed: Boolean by mutableStateOf(false)
+        private set
 
     private val _events = MutableSharedFlow<PaymentEvent>()
     val events: Flow<PaymentEvent> = _events
@@ -136,8 +138,10 @@ class SwishViewModel(
                         appVersion = swishConfiguration.appVersion,
                         paymentMethod = PaymentMethod.Swish(),
                         idempotencyKey = paymentIdempotencyKey
-                    )
+                    ),
+                    onRetry = { isDelayed = true }
                 )
+                isDelayed = false
                 when {
                     waitToken.isFailure -> {
                         Log.d(
@@ -170,7 +174,9 @@ class SwishViewModel(
                         appVersion = swishConfiguration.appVersion,
                         idempotencyKey = paymentIdempotencyKey
                     ),
+                    onRetry = { isDelayed = true }
                 )
+                isDelayed = false
                 when {
                     waitToken.isFailure -> {
                         Log.d(
@@ -215,6 +221,7 @@ class SwishViewModel(
             is SwishStatechart.Companion.SideEffect.ResetState -> {
                 this._subscribe.value = false;
                 this.waitToken = null;
+                this.isDelayed = false
             }
 
             is SwishStatechart.Companion.SideEffect.NotifyPaymentSuccess -> {
@@ -237,7 +244,10 @@ class SwishViewModel(
         // associated with that waitToken and in a status that is not initializing
 
         try {
-            requests.getPaymentRequests().collect { paymentRequestList ->
+            requests.getPaymentRequests(
+                onRetry = { isDelayed = true },
+                onRecovered = { isDelayed = false }
+            ).collect { paymentRequestList ->
                 // If we have a waitToken set in our view model, get the payment request
                 // associated with that waitToken and in a status that is not initializing
                 Log.d("SwishViewModel", "Inside Collect")
@@ -302,6 +312,7 @@ class SwishViewModel(
                 }
             }
         } catch (e: KronorError) {
+            isDelayed = false
             Log.d("SwishViewModel", "Payment Subscription error: $e")
             _transition(SwishStatechart.Companion.Event.Error(e))
         }

--- a/kronor_swish/src/main/res/values-de/strings.xml
+++ b/kronor_swish/src/main/res/values-de/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Zahlung stornieren?
   </string>
+    <string name="payment_taking_longer">Die Zahlung dauert länger als üblich. Bitte warten — wir verarbeiten sie noch</string>
 </resources>

--- a/kronor_swish/src/main/res/values-dk/strings.xml
+++ b/kronor_swish/src/main/res/values-dk/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Afbryd betaling?
   </string>
+    <string name="payment_taking_longer">Betalingen tager længere tid end normalt. Vent venligst — vi behandler den stadig</string>
 </resources>

--- a/kronor_swish/src/main/res/values-et/strings.xml
+++ b/kronor_swish/src/main/res/values-et/strings.xml
@@ -30,4 +30,5 @@
   <string name="cancel_payment">
     Tühista makse?
   </string>
+    <string name="payment_taking_longer">Makse võtab tavapärasest kauem aega. Palun oodake — töötleme seda endiselt</string>
 </resources>

--- a/kronor_swish/src/main/res/values-fi/strings.xml
+++ b/kronor_swish/src/main/res/values-fi/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Keskeytä maksu?
   </string>
+    <string name="payment_taking_longer">Maksu kestää tavallista kauemmin. Odota hetki — käsittelemme sitä edelleen</string>
 </resources>

--- a/kronor_swish/src/main/res/values-fr/strings.xml
+++ b/kronor_swish/src/main/res/values-fr/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Annuler le paiement ?
   </string>
+    <string name="payment_taking_longer">Le paiement prend plus de temps que prévu. Merci de patienter — il est toujours en cours</string>
 </resources>

--- a/kronor_swish/src/main/res/values-is/strings.xml
+++ b/kronor_swish/src/main/res/values-is/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Hætta við greiðslu?
   </string>
+    <string name="payment_taking_longer">Greiðslan tekur lengri tíma en venjulega. Augnablik — við erum enn að vinna úr henni</string>
 </resources>

--- a/kronor_swish/src/main/res/values-lt/strings.xml
+++ b/kronor_swish/src/main/res/values-lt/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Atšaukti mokėjimą?
   </string>
+    <string name="payment_taking_longer">Mokėjimas užtrunka ilgiau nei įprastai. Palaukite — mes vis dar jį apdorojame</string>
 </resources>

--- a/kronor_swish/src/main/res/values-lv/strings.xml
+++ b/kronor_swish/src/main/res/values-lv/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Atcelt maksājumu?
   </string>
+    <string name="payment_taking_longer">Maksājums aizņem ilgāku laiku nekā parasti. Lūdzu, uzgaidiet — mēs to joprojām apstrādājam</string>
 </resources>

--- a/kronor_swish/src/main/res/values-nl/strings.xml
+++ b/kronor_swish/src/main/res/values-nl/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Betaling annuleren?
   </string>
+    <string name="payment_taking_longer">De betaling duurt langer dan normaal. Even geduld — we verwerken deze nog</string>
 </resources>

--- a/kronor_swish/src/main/res/values-no/strings.xml
+++ b/kronor_swish/src/main/res/values-no/strings.xml
@@ -24,4 +24,5 @@
   <string name="cancel_payment">
     Avbryt betaling?
   </string>
+    <string name="payment_taking_longer">Betalingen tar lengre tid enn vanlig. Vent litt — vi behandler den fortsatt</string>
 </resources>

--- a/kronor_swish/src/main/res/values-pl/strings.xml
+++ b/kronor_swish/src/main/res/values-pl/strings.xml
@@ -36,4 +36,5 @@
   <string name="cancel_payment">
     Anulować płatność?
   </string>
+    <string name="payment_taking_longer">Płatność trwa dłużej niż zwykle. Prosimy czekać — wciąż ją przetwarzamy</string>
 </resources>

--- a/kronor_swish/src/main/res/values-sv/strings.xml
+++ b/kronor_swish/src/main/res/values-sv/strings.xml
@@ -18,4 +18,5 @@
     <string name="pay_now">Betala nu</string>
     <string name="enter_swish_number">Ange ditt Swish-telefonnummer</string>
     <string name="initializing">Initierar…</string>
+    <string name="payment_taking_longer">Betalningen tar längre tid än vanligt. Vänta lite — vi behandlar den fortfarande</string>
 </resources>

--- a/kronor_swish/src/main/res/values/strings.xml
+++ b/kronor_swish/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="pay_now">Pay Now</string>
     <string name="enter_swish_number">Enter your Swish phone number</string>
     <string name="initializing">Initializing…</string>
+    <string name="payment_taking_longer">The payment is taking longer than usual. Hang tight — we\'re still processing it</string>
 </resources>

--- a/kronor_webview_payment_gateway/build.gradle
+++ b/kronor_webview_payment_gateway/build.gradle
@@ -103,6 +103,7 @@ android {
 
 dependencies {
 
+    implementation "androidx.compose.animation:animation:$compose_ui_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.compose.ui:ui:$compose_ui_version"

--- a/kronor_webview_payment_gateway/src/main/java/io/kronor/component/webview_payment_gateway/WebviewGatewayComponent.kt
+++ b/kronor_webview_payment_gateway/src/main/java/io/kronor/component/webview_payment_gateway/WebviewGatewayComponent.kt
@@ -9,6 +9,9 @@ import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
@@ -55,6 +58,7 @@ fun WebviewGatewayComponent(
         viewModel::transition,
         viewModel.webviewGatewayState,
         viewModel.paymentGatewayUrl,
+        viewModel.isDelayed,
         modifier = modifier
     )
 }
@@ -64,13 +68,16 @@ private fun WebviewGatewayScreen(
     transition: (WebviewGatewayStatechart.Companion.Event) -> Unit,
     state: State<WebviewGatewayStatechart.Companion.State>,
     paymentGatewayUrl: Uri,
+    isDelayed: Boolean,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
     Surface(
         modifier = modifier, color = MaterialTheme.colors.background
     ) {
-        when (state.value) {
+        Column {
+            Box(modifier = Modifier.weight(1f)) {
+                when (state.value) {
             WebviewGatewayStatechart.Companion.State.Initializing -> {
                 LaunchedEffect(Unit) {
                     transition(WebviewGatewayStatechart.Companion.Event.Initialize(context))
@@ -122,6 +129,35 @@ private fun WebviewGatewayScreen(
                     WebviewGatewayPaymentCompleted(modifier = Modifier.fillMaxSize())
                 }
             }
+                }
+            }
+            PaymentDelayedNotice(isDelayed)
+        }
+    }
+}
+
+@Composable
+private fun PaymentDelayedNotice(isDelayed: Boolean) {
+    AnimatedVisibility(visible = isDelayed, enter = fadeIn(), exit = fadeOut()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                strokeWidth = 2.dp
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.payment_taking_longer),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onBackground.copy(alpha = 0.6f),
+                textAlign = TextAlign.Center
+            )
         }
     }
 }
@@ -283,4 +319,3 @@ private fun WebviewGatewayPaymentRejected(modifier: Modifier = Modifier) {
         Text(stringResource(R.string.payment_rejected))
     }
 }
-

--- a/kronor_webview_payment_gateway/src/main/java/io/kronor/component/webview_payment_gateway/WebviewGatewayViewModel.kt
+++ b/kronor_webview_payment_gateway/src/main/java/io/kronor/component/webview_payment_gateway/WebviewGatewayViewModel.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.apollographql.apollo3.exception.ApolloException
 import com.tinder.StateMachine
 import io.kronor.api.*
 import io.kronor.api.type.PaymentStatusEnum
@@ -54,6 +53,7 @@ class WebviewGatewayViewModel(
     internal val subscribe : Boolean by _subscribe
     private var intentReceived: Boolean = false
     private var deviceFingerprint: String? = null
+    private val paymentIdempotencyKey: String = UUID.randomUUID().toString()
     private val constructedRedirectUrl  : Uri =
         webviewGatewayConfiguration.redirectUrl
             .buildUpon()
@@ -150,7 +150,8 @@ class WebviewGatewayViewModel(
                         deviceFingerprint = deviceFingerprint ?: "fingerprint not found",
                         appName = webviewGatewayConfiguration.appName,
                         appVersion = webviewGatewayConfiguration.appVersion,
-                        paymentMethod = paymentMethod
+                        paymentMethod = paymentMethod,
+                        idempotencyKey = paymentIdempotencyKey
                     )
                 )
                 when {
@@ -299,11 +300,9 @@ class WebviewGatewayViewModel(
                     }
                 }
             }
-        } catch (e: ApolloException) {
+        } catch (e: KronorError) {
             Log.d("WebviewGatewayViewModel", "Payment Subscription error: $e")
-            _transition(
-                WebviewGatewayStatechart.Companion.Event.Error(KronorError.NetworkError(e))
-            )
+            _transition(WebviewGatewayStatechart.Companion.Event.Error(e))
         }
     }
 

--- a/kronor_webview_payment_gateway/src/main/java/io/kronor/component/webview_payment_gateway/WebviewGatewayViewModel.kt
+++ b/kronor_webview_payment_gateway/src/main/java/io/kronor/component/webview_payment_gateway/WebviewGatewayViewModel.kt
@@ -72,6 +72,8 @@ class WebviewGatewayViewModel(
     internal val webviewGatewayState: State<WebviewGatewayStatechart.Companion.State> = _webviewGatewayState
     private var paymentRequest: PaymentStatusSubscription.PaymentRequest? by mutableStateOf(null)
     private var waitToken: String? by mutableStateOf(null)
+    internal var isDelayed: Boolean by mutableStateOf(false)
+        private set
     val paymentGatewayUrl: Uri = constructPaymentGatewayUrl(
         environment = webviewGatewayConfiguration.environment,
         sessionToken = webviewGatewayConfiguration.sessionToken,
@@ -152,8 +154,10 @@ class WebviewGatewayViewModel(
                         appVersion = webviewGatewayConfiguration.appVersion,
                         paymentMethod = paymentMethod,
                         idempotencyKey = paymentIdempotencyKey
-                    )
+                    ),
+                    onRetry = { isDelayed = true }
                 )
+                isDelayed = false
                 when {
                     waitToken.isFailure -> {
                         Log.d(
@@ -194,6 +198,7 @@ class WebviewGatewayViewModel(
             }
 
             is WebviewGatewayStatechart.Companion.SideEffect.ResetState -> {
+                isDelayed = false
                 Log.d("WebviewGatewayViewModel", "Reset payment flow")
                 val waitToken = requests.cancelPayment()
                 when {
@@ -244,7 +249,10 @@ class WebviewGatewayViewModel(
         // associated with that waitToken and in a status that is not initializing
 
         try {
-            requests.getPaymentRequests().collect { paymentRequestList ->
+            requests.getPaymentRequests(
+                onRetry = { isDelayed = true },
+                onRecovered = { isDelayed = false }
+            ).collect { paymentRequestList ->
                 // If we have a waitToken set in our view model, get the payment request
                 // associated with that waitToken and in a status that is not initializing
                 Log.d("WebviewGatewayViewModel", "Inside Collect")
@@ -301,6 +309,7 @@ class WebviewGatewayViewModel(
                 }
             }
         } catch (e: KronorError) {
+            isDelayed = false
             Log.d("WebviewGatewayViewModel", "Payment Subscription error: $e")
             _transition(WebviewGatewayStatechart.Companion.Event.Error(e))
         }

--- a/kronor_webview_payment_gateway/src/main/res/values-de/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-de/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Bitte warten, bis Ihre Zahlung abgeschlossen ist
   </string>
+    <string name="payment_taking_longer">Die Zahlung dauert länger als üblich. Bitte warten — wir verarbeiten sie noch</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-dk/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-dk/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Gennemfører betaling, vent venligst
   </string>
+    <string name="payment_taking_longer">Betalingen tager længere tid end normalt. Vent venligst — vi behandler den stadig</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-et/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-et/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Palun oodake, makset sooritatakse
   </string>
+    <string name="payment_taking_longer">Makse võtab tavapärasest kauem aega. Palun oodake — töötleme seda endiselt</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-fi/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-fi/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Vahvistetaaan maksutapahtumaasi, odota
   </string>
+    <string name="payment_taking_longer">Maksu kestää tavallista kauemmin. Odota hetki — käsittelemme sitä edelleen</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-fr/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-fr/strings.xml
@@ -15,4 +15,5 @@
   <string name="waiting_for_payment">
     Finalisation de votre paiement, veuillez patienter
   </string>
+    <string name="payment_taking_longer">Le paiement prend plus de temps que prévu. Merci de patienter — il est toujours en cours</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-is/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-is/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Klárar greiðslu, vinsamlegast bíðið
   </string>
+    <string name="payment_taking_longer">Greiðslan tekur lengri tíma en venjulega. Augnablik — við erum enn að vinna úr henni</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-lt/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-lt/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Mokėjimas užbaigiamas, prašome palaukti
   </string>
+    <string name="payment_taking_longer">Mokėjimas užtrunka ilgiau nei įprastai. Palaukite — mes vis dar jį apdorojame</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-lv/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-lv/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Notiek maksājuma apstrāde, lūdzu, uzgaidiet
   </string>
+    <string name="payment_taking_longer">Maksājums aizņem ilgāku laiku nekā parasti. Lūdzu, uzgaidiet — mēs to joprojām apstrādājam</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-nl/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-nl/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     De betaling wordt afgerond, een ogenblik geduld alsjeblieft.
   </string>
+    <string name="payment_taking_longer">De betaling duurt langer dan normaal. Even geduld — we verwerken deze nog</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-no/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-no/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Gjennomfører betaling, vennligst vent
   </string>
+    <string name="payment_taking_longer">Betalingen tar lengre tid enn vanlig. Vent litt — vi behandler den fortsatt</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-pl/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-pl/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Dokonujemy płatności, proszę czekać
   </string>
+    <string name="payment_taking_longer">Płatność trwa dłużej niż zwykle. Prosimy czekać — wciąż ją przetwarzamy</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values-sv/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values-sv/strings.xml
@@ -14,4 +14,5 @@
   <string name="waiting_for_payment">
     Slutför din betalning, vänligen vänta.
   </string>
+    <string name="payment_taking_longer">Betalningen tar längre tid än vanligt. Vänta lite — vi behandlar den fortfarande</string>
 </resources>

--- a/kronor_webview_payment_gateway/src/main/res/values/strings.xml
+++ b/kronor_webview_payment_gateway/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
   <string name="waiting_for_payment">
     Checking the payment status
   </string>
+    <string name="payment_taking_longer">The payment is taking longer than usual. Hang tight — we\'re still processing it</string>
 </resources>


### PR DESCRIPTION
## Summary

- retry payment mutations on transport errors and GraphQL TEMPORARY_FAILURE responses
- reuse one idempotency key across automatic and manual retries for each logical payment attempt
- resubscribe to payment-status streams after transient failures with a bounded retry budget
- show a localized, fading payment-is-taking-longer notice while a mutation or status stream is retrying
- hide the notice on recovery and reset the consecutive subscription-failure budget after every successful update
- add mock-server and Flow coverage for stable request keys, retry notifications, recovery, and transient/fatal error handling
- quote the example-app merchant token safely so local Android Studio runs compile

## Root cause

The Android SDK used Apollo Kotlin default no-retry behavior and generated a new idempotency key inside every mutation call. A transient write or websocket failure therefore surfaced immediately to the shopper, while retrying the payment flow could bypass backend deduplication.

## iOS parity

This ports the resilience behavior from merged kronor-ios PR 47: six total attempts over a 15.5-second exponential-backoff window, customer-visible delayed-processing feedback, recovery callbacks, and consecutive-failure reset after a successful status update. Android already had the recoverable Cancel and Try Again error views.

## Impact

Transient payment failures remain in the in-progress UI while the SDK retries. Validation and other fatal GraphQL errors still surface immediately, and sustained subscription failures still reach the existing recoverable error screen after the retry budget is exhausted.

## Validation

- GitHub Build workflow confirmed to run kronor_api debug and release unit tests
- example app assembles successfully with the local merchant token
- API retry tests pass
- changed payment modules compile successfully
- delayed notice visually verified on the API 36.1 emulator by forcing airplane mode after session creation
- git diff --check passes

Closes kronor-io/kronor#5819
Closes kronor-io/kronor#5820