### PR TITLE
Upgrade a few dependencies.

### DIFF
--- a/build-logic/src/main/kotlin/KronorAndroidApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/KronorAndroidApplicationPlugin.kt
@@ -8,11 +8,11 @@ class KronorAndroidApplicationPlugin : Plugin<Project> {
         pluginManager.apply("com.android.application")
 
         extensions.configure(ApplicationExtension::class.java) {
-            compileSdk = 36
+            compileSdk = 37
 
             defaultConfig {
-                minSdk = 21
-                targetSdk = 36
+                minSdk = 24
+                targetSdk = 37
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             }
 

--- a/build-logic/src/main/kotlin/KronorAndroidLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/KronorAndroidLibraryPlugin.kt
@@ -8,13 +8,13 @@ class KronorAndroidLibraryPlugin : Plugin<Project> {
         pluginManager.apply("com.android.library")
 
         extensions.configure(LibraryExtension::class.java) {
-            compileSdk = 36
+            compileSdk = 37
 
             defaultConfig {
-                minSdk = 21
+                minSdk = 24
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
                 consumerProguardFiles("consumer-rules.pro")
-                aarMetadata.minCompileSdk = 21
+                aarMetadata.minCompileSdk = 24
             }
 
             buildTypes.named("release") {
@@ -32,8 +32,8 @@ class KronorAndroidLibraryPlugin : Plugin<Project> {
                 targetCompatibility = JavaVersion.VERSION_17
             }
 
-            lint.targetSdk = 36
-            testOptions.targetSdk = 36
+            lint.targetSdk = 37
+            testOptions.targetSdk = 37
         }
     }
 }

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -38,7 +38,7 @@ apollo {
 }
 
 dependencies {
-    implementation libs.androidx.core.ktx
+    implementation libs.androidx.core
     implementation libs.androidx.appcompat
     implementation libs.google.material
     implementation libs.androidx.constraintlayout

--- a/example-app/src/main/java/io/kronor/example/MainActivity.kt
+++ b/example-app/src/main/java/io/kronor/example/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.kronor.example
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -26,7 +27,6 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.rememberScaffoldState
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
@@ -39,6 +39,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -103,6 +105,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Locale
+import kotlin.enums.enumEntries
 
 
 class MainActivity : ComponentActivity() {
@@ -143,6 +146,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@SuppressLint("ComposeViewModelForwarding", "ComposeModifierReused")
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun KronorTestApp(viewModel: MainViewModel, newIntent: State<Intent?>, modifier: Modifier = Modifier) {
@@ -652,11 +656,13 @@ fun PaymentMethodsScreen(
         }
     }
 
-    val scaffoldState = rememberScaffoldState()
+    val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
     Scaffold(
-        modifier = modifier.fillMaxSize(), topBar = {
+        modifier = modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
             TopAppBar(title = { Text("Kronor Payments Demo") }, )
         }
     ) { paddingValues ->
@@ -774,7 +780,7 @@ fun PaymentMethodsScreen(
                                     useFallbackState = false
                                 } else {
                                     scope.launch {
-                                        scaffoldState.snackbarHostState.showSnackbar(
+                                        snackbarHostState.showSnackbar(
                                             "Payment method ${selectedPaymentMethod.toPaymentGatewayMethod()} doesn't have a native implementation"
                                         )
                                     }
@@ -1104,9 +1110,9 @@ fun setSupportedCountriesAndCurrencies(
         }
 
         else -> {
-            setSupportedCountries(enumValues())
-            setSupportedCurrencies(enumValues())
-            setSupportedGateways(enumValues())
+            setSupportedCountries(enumEntries<Country>().toTypedArray())
+            setSupportedCurrencies(enumEntries<SupportedCurrencyEnum>().toTypedArray())
+            setSupportedGateways(enumEntries<GatewayEnum>().toTypedArray())
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,29 +1,29 @@
 [versions]
 agp = "9.3.1"
-kotlin = "2.2.10"
+kotlin = "2.4.10"
 apollo = "4.4.1"
 nexus-publish = "2.0.0"
 
-compose-bom = "2025.09.00"
+compose-bom = "2026.08.00"
 compose-material3 = "1.4.0"
-compose-lint = "1.4.2"
-activity = "1.11.0"
-appcompat = "1.7.1"
-constraintlayout = "2.2.1"
-core-ktx = "1.17.0"
-lifecycle = "2.9.4"
-material = "1.13.0"
-navigation = "2.9.4"
-webkit = "1.14.0"
+compose-lint = "1.5.4"
+activity = "1.13.0"
+appcompat = "1.8.0"
+constraintlayout = "2.2.2"
+core = "1.19.0"
+lifecycle = "2.11.0"
+material = "1.14.0"
+navigation = "2.9.8"
+webkit = "1.17.0"
 
 apollo-adapters = "0.7.0"
 junit4 = "4.13.2"
 androidx-junit = "1.3.0"
 espresso = "3.7.0"
-mockwebserver = "4.10.0"
+mockwebserver = "5.5.0"
 statemachine = "0.2.0"
-trustly = "4.0.2"
-zxing = "3.5.3"
+trustly = "4.1.1"
+zxing = "3.5.4"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -32,7 +32,7 @@ compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compil
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
-androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
+androidx-core = { module = "androidx.core:core", version.ref = "core" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }

--- a/kronor_api/build.gradle
+++ b/kronor_api/build.gradle
@@ -31,7 +31,7 @@ apollo {
 }
 
 dependencies {
-    implementation libs.androidx.core.ktx
+    implementation libs.androidx.core
     implementation libs.apollo.runtime
     implementation libs.apollo.adapters.core
     testImplementation libs.junit4


### PR DESCRIPTION
- Also update the minSdk target to 24 (webkit now requires it) - this covers upto 99% of android users.
- and target android sdk 37

Changelog generated by codex:

**Changelog Summary**
- **Kotlin `2.2.10 -> 2.4.10`**: stable context parameters, explicit backing fields, improved annotation targets, stable UUID API, Java 26 and Gradle 9.5 support, followed by compiler and scripting fixes in 2.4.10. [Kotlin 2.4 changes](https://kotlinlang.org/docs/whatsnew24.html), [2.4.10 release](https://github.com/JetBrains/kotlin/releases/tag/v2.4.10)
- **Compose BOM `2025.09.00 -> 2026.08.00`**: resolves the main Compose libraries to `1.12.0`. Includes credential-manager semantics, sound interactions, transition/shared-element APIs, runtime correctness and memory fixes. Compose 1.12 requires API 37 compilation and AGP 9.2+, both now satisfied. [Compose UI](https://developer.android.com/jetpack/androidx/releases/compose-ui), [Runtime](https://developer.android.com/jetpack/androidx/releases/compose-runtime), [Animation](https://developer.android.com/jetpack/androidx/releases/compose-animation)
- **Compose Lints `1.4.2 -> 1.5.4`**: newer lint/Kotlin compatibility, improved redundant-composable detection, fewer false positives, and a new `ignore-annotated` escape hatch. [1.5.4 notes](https://github.com/slackhq/compose-lints/releases/tag/1.5.4)
- **Activity Compose `1.11.0 -> 1.13.0`**: migration of back handling onto `NavigationEvent`, dialog Compose support, picture-in-picture state support, edge-to-edge fixes and Activity Result security fixes. Raises `minSdk` to 23. [Changelog](https://developer.android.com/jetpack/androidx/releases/activity)
- **AppCompat `1.7.1 -> 1.8.0`**: adds `TextAppearanceSpanCompat` and removes obsolete API-21 compatibility handling. Raises `minSdk` to 23. [Changelog](https://developer.android.com/jetpack/androidx/releases/appcompat)
- **ConstraintLayout `2.2.1 -> 2.2.2`**: maintenance and bug-fix release. [ConstraintLayout releases](https://developer.android.com/jetpack/androidx/releases/constraintlayout)
- **Core KTX `1.17.0 -> 1.19.0`**: projected-notification and picture-in-picture compatibility APIs, accessibility improvements and variable-font support. `core-ktx` APIs have been merged into `core`; the KTX artifact remains as an empty compatibility artifact. [Changelog](https://developer.android.com/jetpack/androidx/releases/core)
- **Lifecycle `2.9.4 -> 2.11.0`**: scoped lifecycle owners and ViewModels for Compose, nullable `SavedStateHandle.saved`, Navigation3 integration and broader KMP support. Raises `minSdk` to 23. [Changelog](https://developer.android.com/jetpack/androidx/releases/lifecycle)
- **Material Components `1.13.0 -> 1.14.0`**: numerous BottomSheet, accessibility, nested-scrolling, chip, FAB and search fixes, plus Material 3 Expressive styles. Raises `minSdk` to 23. The Views library is now in maintenance mode. [1.14.0 notes](https://github.com/material-components/material-components-android/releases/tag/1.14.0)
- **Navigation `2.9.4 -> 2.9.8`**: AGP 9 built-in Kotlin support for Safe Args, configuration-cache fixes, modern AGP API usage, SavedStateHandle fixes and a predictive-back race/NPE fix. [Changelog](https://developer.android.com/jetpack/androidx/releases/navigation)
- **WebKit `1.14.0 -> 1.17.0`**: partitioned-cookie support, async startup/navigation APIs, prefetch/prerender and HTTP cache APIs, favicon controls and renderer-crash lint checks. Raises `minSdk` first to 23 and then to 24. [Changelog](https://developer.android.com/jetpack/androidx/releases/webkit)
- **MockWebServer `4.10.0 -> 5.5.0`**: major OkHttp 5 migration. It remains test-only here, but packaging and some APIs changed; new code should consider the `mockwebserver3` APIs. [OkHttp releases](https://github.com/square/okhttp/releases) - PS: No releases exist here, the actual logs are at: https://lysine.dev/okhttp/changelogs/changelog/
- **Trustly `4.0.2 -> 4.1.1`**: 4.1.0 updates build tooling, Java 21, API 36, AppCompat and Browser; 4.1.1 adds URL safety checks addressing a cross-app scripting issue in `TrustlyWebView`. [Trustly releases](https://github.com/trustly/TrustlyAndroidSdk/releases)
- **ZXing `3.5.3 -> 3.5.4`**: QR multi-reader metadata fix, stricter email/PDF417 validation, safer and rotatable RGB luminance sources, grayscale support and ITF decoding improvements. [3.5.4 notes](https://github.com/zxing/zxing/releases/tag/zxing-3.5.4)